### PR TITLE
Add new GameEngine project to solution

### DIFF
--- a/OpenCnC.Net.GameEngine.sln
+++ b/OpenCnC.Net.GameEngine.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenCnC.Net.GameEngine", "Src\OpenCnC.Net.GameEngine\OpenCnC.Net.GameEngine.csproj", "{994D5A3C-D19A-468D-B08D-2A480E753833}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -10,5 +12,11 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{994D5A3C-D19A-468D-B08D-2A480E753833}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{994D5A3C-D19A-468D-B08D-2A480E753833}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{994D5A3C-D19A-468D-B08D-2A480E753833}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{994D5A3C-D19A-468D-B08D-2A480E753833}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Src/OpenCnC.Net.GameEngine/OpenCnC.Net.GameEngine.csproj
+++ b/Src/OpenCnC.Net.GameEngine/OpenCnC.Net.GameEngine.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>OpenCnC.Net.GameEngine</RootNamespace>
+        <DefineTrace>true</DefineTrace>
+    </PropertyGroup>
+    
+    <Choose>
+        <When Condition="'$(Configuration)' == 'Debug'">
+            <PropertyGroup>
+                <DefineDebug>true</DefineDebug>
+                <DebugSymbols>true</DebugSymbols>
+                <DebugType>full</DebugType>
+                <Optimize>false</Optimize>
+            </PropertyGroup>
+        </When>
+        <When Condition="'$(Configuration)' == 'Release'">
+            <PropertyGroup>
+                <DefineDebug>false</DefineDebug>
+                <DebugSymbols>false</DebugSymbols>
+                <DebugType>portable</DebugType>
+                <Optimize>none</Optimize>
+            </PropertyGroup>
+        </When>
+    </Choose>
+
+</Project>


### PR DESCRIPTION
Introduced the `OpenCnC.Net.GameEngine` project targeting .NET 8.0, with nullable and implicit using features enabled.

Updated the solution file to include this project with appropriate configurations for Debug and Release builds.